### PR TITLE
updates resource versions and adds firewall rule for sql server demo

### DIFF
--- a/azure-votes-sql/manifests/azure_v1_resourcegroup.yaml
+++ b/azure-votes-sql/manifests/azure_v1_resourcegroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: azure.microsoft.com/v1
+apiVersion: azure.microsoft.com/v1alpha1
 kind: ResourceGroup
 metadata:
   name: aso-sql-rg

--- a/azure-votes-sql/manifests/azure_v1_sqldatabase.yaml
+++ b/azure-votes-sql/manifests/azure_v1_sqldatabase.yaml
@@ -1,5 +1,5 @@
-apiVersion: azure.microsoft.com/v1
-kind: SqlDatabase
+apiVersion: azure.microsoft.com/v1alpha1
+kind: AzureSqlDatabase
 metadata:
   name:  sqldatabase-aso-demo
 spec:

--- a/azure-votes-sql/manifests/azure_v1_sqlserver.yaml
+++ b/azure-votes-sql/manifests/azure_v1_sqlserver.yaml
@@ -1,8 +1,7 @@
-apiVersion: azure.microsoft.com/v1
-kind: SqlServer
+apiVersion: azure.microsoft.com/v1alpha1
+kind: AzureSqlServer
 metadata:
   name: sqlserver-aso-demo
 spec:
   location: "westus"
   resourcegroup: "aso-sql-rg"
-  allowazureserviceaccess: true

--- a/azure-votes-sql/manifests/azure_v1alpha1_azuresqlfirewallrule.yaml
+++ b/azure-votes-sql/manifests/azure_v1alpha1_azuresqlfirewallrule.yaml
@@ -1,0 +1,11 @@
+apiVersion: azure.microsoft.com/v1alpha1
+kind: AzureSqlFirewallRule
+metadata:
+  name: saso-sql-fwrule
+spec:
+  resourcegroup: aso-sql-rg
+  server:  sqlserver-aso-demo
+  
+  # this IP range enables Azure Service access
+  startipaddress: 0.0.0.0
+  endipaddress: 0.0.0.0


### PR DESCRIPTION
The services used by the SQL Server demo were moved from `v1` to `v1alpha1`

Also, the opening of firewall ports to other Azure services was removed so firewall rule requests are now the way to do that.